### PR TITLE
download the spaCy model through Conda

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -5,17 +5,12 @@ Rough script exploring approaches to extract control details from a FedRAMP SSP 
 ## Setup
 
 1. [Install Conda.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
-1. Set up Conda environment.
+1. Set up Conda environment. From this directory, run:
 
    ```sh
+   conda config --add channels conda-forge
    conda env create -f environment.yml
    conda activate fismatic
-   ```
-
-1. Download the language model.
-
-   ```sh
-   python -m spacy download en_core_web_lg
    ```
 
 ## Running

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pytest
   - rope
   - spacy=2
+  - spacy-model-en_core_web_lg


### PR DESCRIPTION
Part of #36.

This downloaded ok, but on Windows, was getting a `ValueError: could not broadcast input array from shape (NN) into shape (NN)` when trying to `load()` the model. Might be a versioning issue between the spaCy library and model...?